### PR TITLE
[codex] Clarify skills install key hints

### DIFF
--- a/apps/docs/content/docs/en/installation.md
+++ b/apps/docs/content/docs/en/installation.md
@@ -81,7 +81,7 @@ For normal upgrades, rerun the install command. Use `ONE_FORCE` only for downgra
 one skills install
 ```
 
-It detects supported agents on your machine and lets you choose where to install the skills. The default is all detected agents; use Space to toggle and Enter to confirm.
+It detects supported agents on your machine and lets you choose where to install the skills. Only Claude Code is pre-selected by default; use Up/Down to move, Space to check or uncheck, and Enter to start installing.
 
 Non-interactive usage:
 

--- a/apps/docs/content/docs/en/skills.md
+++ b/apps/docs/content/docs/en/skills.md
@@ -52,7 +52,7 @@ one skills install --yes                    # install to every detected agent (C
 Behavior:
 
 1. **Auto-detects** installed coding agents on the machine — Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot, OpenCode, Cline, and 50+ others. Full list: `one skills install --help`.
-2. **Interactive mode**: opens a multi-select list; space toggles and enter confirms. Only Claude Code is pre-checked.
+2. **Interactive mode**: opens a multi-select list; Up/Down moves the cursor, Space checks or unchecks the current agent, and Enter starts installation. Only Claude Code is pre-checked.
 3. **Non-TTY or `--yes`**: installs to every detected agent. If none are detected, falls back to Claude Code's default path.
 4. **Materialises** every One CLI skill into `~/.one/skills-store/one-bundled/<skill-name>/`. Each target agent gets a **symlink** in its global skills directory pointing at the store.
 5. **Windows fallback**: when the OS rejects symlinks (no dev-mode privilege), the CLI silently switches to a directory copy.

--- a/apps/docs/content/docs/zh/installation.md
+++ b/apps/docs/content/docs/zh/installation.md
@@ -81,7 +81,7 @@ Windows 类似——下载 `one-cli_windows_amd64.zip`，解压把 `one.exe` 放
 one skills install
 ```
 
-它会自动检测本机已装的所有受支持 agent，让你勾选装到哪些（默认全选；空格切换；回车确认）。
+它会自动检测本机已装的所有受支持 agent，让你勾选装到哪些（默认只勾 Claude Code；↑/↓ 移动光标；空格勾选 / 取消；回车开始安装）。
 
 非交互场景：
 

--- a/apps/docs/content/docs/zh/skills.md
+++ b/apps/docs/content/docs/zh/skills.md
@@ -52,7 +52,7 @@ one skills install --yes         # 装到所有检测到的 agent（CI 用）
 行为：
 
 1. **自动检测**本机已安装的 coding agent（Claude Code / Cursor / Codex / Gemini CLI / GitHub Copilot / OpenCode / Cline 等 50+；完整列表见 `one skills install --help`）
-2. **交互模式**：弹出多选列表，空格切换、回车确认；默认只勾 Claude Code
+2. **交互模式**：弹出多选列表，↑/↓ 移动光标，空格勾选 / 取消，回车开始安装；默认只勾 Claude Code
 3. **非 TTY 或 `--yes`**：装到所有检测到的；都没检测到时 fallback 到 Claude Code 默认路径
 4. **物化**到 `~/.one/skills-store/one-bundled/<skill-name>/`，每个目标 agent 在其 global skills 目录建一个 **symlink** 指向 store
 5. **Windows fallback**：symlink 失败时（无 dev mode 权限）自动改为整目录 copy

--- a/apps/docs/content/tutorials/en/skills-install.mdx
+++ b/apps/docs/content/tutorials/en/skills-install.mdx
@@ -17,7 +17,7 @@ Interactive (recommended on a new machine):
 one skills install
 ```
 
-It auto-detects every supported coding agent installed on this machine (Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot, OpenCode, Cline, and 50+ more). You get a multi-select prompt; only Claude Code is pre-checked. Space to toggle, Enter to confirm.
+It auto-detects every supported coding agent installed on this machine (Claude Code, Cursor, Codex, Gemini CLI, GitHub Copilot, OpenCode, Cline, and 50+ more). You get a multi-select prompt; only Claude Code is pre-checked. Use Up/Down to move, Space to check or uncheck, and Enter to start installing.
 
 Non-interactive forms:
 

--- a/apps/docs/content/tutorials/zh/skills-install.mdx
+++ b/apps/docs/content/tutorials/zh/skills-install.mdx
@@ -15,7 +15,7 @@ description: 跑 one skills install，让 Claude Code、Cursor、Codex（以及 
 one skills install
 ```
 
-会自动检测本机所有支持的 coding agent（Claude Code、Cursor、Codex、Gemini CLI、GitHub Copilot、OpenCode、Cline 等 50+）。给你一个多选框，默认只勾 Claude Code。空格切换，回车确认。
+会自动检测本机所有支持的 coding agent（Claude Code、Cursor、Codex、Gemini CLI、GitHub Copilot、OpenCode、Cline 等 50+）。给你一个多选框，默认只勾 Claude Code。↑/↓ 移动光标，空格勾选 / 取消，回车开始安装。
 
 非交互式：
 

--- a/packages/cli/internal/cmd/skillscmd/cmd.go
+++ b/packages/cli/internal/cmd/skillscmd/cmd.go
@@ -54,7 +54,7 @@ func newInstallCmd() *cobra.Command {
 
 会先自动检测所有受支持的 coding agent（Claude Code / Cursor / Codex /
 Gemini CLI / GitHub Copilot / OpenCode / Cline 等 50+），然后让你
-**勾选**装到哪些（默认只勾 Claude Code；按需勾选其他；空格切换；回车确认）。
+**勾选**装到哪些（默认只勾 Claude Code；↑/↓ 移动；空格勾选/取消；回车开始安装）。
 
 非交互场景：
   --agent claude-code --agent cursor   # 只装这两个
@@ -149,7 +149,7 @@ func resolveTargets(flags *installFlags) ([]agentskills.Agent, error) {
 		}
 	}
 	picked, err := prompt.MultiSelect(
-		"选择要安装到的 agent（空格切换，回车确认；默认仅 Claude Code）",
+		"选择要安装到的 agent（↑/↓ 移动，空格勾选/取消，回车开始安装；默认仅 Claude Code）",
 		options, defaults)
 	if err != nil {
 		return nil, err

--- a/packages/cli/testdata/reference/help/skills_install.txt
+++ b/packages/cli/testdata/reference/help/skills_install.txt
@@ -2,7 +2,7 @@
 
 会先自动检测所有受支持的 coding agent（Claude Code / Cursor / Codex /
 Gemini CLI / GitHub Copilot / OpenCode / Cline 等 50+），然后让你
-**勾选**装到哪些（默认只勾 Claude Code；按需勾选其他；空格切换；回车确认）。
+**勾选**装到哪些（默认只勾 Claude Code；↑/↓ 移动；空格勾选/取消；回车开始安装）。
 
 非交互场景：
   --agent claude-code --agent cursor   # 只装这两个


### PR DESCRIPTION
## Summary
- clarify the interactive key hints for one skills install
- sync the help snapshot and English/Chinese docs
- correct the install docs to say only Claude Code is pre-selected by default

## Validation
- task verify-docs
- go test ./internal/cli/ -run TestHelpSnapshots

## Notes
The current multi-select behavior comes from charmbracelet/huh v1.0.0: Up/Down moves, Space/x toggles, and Enter submits. In this command, submit starts installation.